### PR TITLE
Bump manylinux to recent version.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,10 @@ jobs:
     strategy:
       matrix:
         python-path: ['cp37-cp37m', 'cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311']
-    container: quay.io/pypa/manylinux_2_24_x86_64:latest
+    container: quay.io/pypa/manylinux_2_28_x86_64:latest
     env:
       TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
       TWINE_USERNAME: ${{secrets.TWINE_USERNAME}}
-
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -26,12 +25,13 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - run: apt update && apt install libffi-dev libssl-dev -y
+          target: x86_64-unknown-linux-gnu
+      - run: yum makecache && yum -y install libffi-devel openssl-devel
       - run: /opt/python/${{ matrix.python-path }}/bin/python -m venv .venv
       - run: .venv/bin/pip install -U pip wheel
       - run: .venv/bin/pip install -U twine maturin
       - run: .venv/bin/pip install -r requirements.txt
-      - run: OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu/ OPENSSL_INCLUDE_DIR=/usr/include/openssl .venv/bin/maturin build --release --strip --manylinux 2_24 -i /opt/python/${{ matrix.python-path }}/bin/python --target x86_64-unknown-linux-gnu
+      - run: OPENSSL_STATIC=1 .venv/bin/maturin build --release --strip --manylinux 2_28 -i /opt/python/${{ matrix.python-path }}/bin/python --target x86_64-unknown-linux-gnu
       - run: .venv/bin/pip install rfernet --no-index -f target/wheels
       - run: .venv/bin/pytest
       - run: .venv/bin/twine upload --non-interactive --skip-existing target/wheels/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,3 +65,27 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+
+  test_manylinux_release:
+      name: Test manylinux release build
+      runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          python-path: ['cp37-cp37m', 'cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311']
+      container: quay.io/pypa/manylinux_2_28_x86_64:latest
+      steps:
+        - uses: actions/checkout@v2
+        - uses: actions-rs/toolchain@v1
+          with:
+            profile: minimal
+            toolchain: stable
+            override: true
+            target: x86_64-unknown-linux-gnu
+        - run: yum makecache && yum -y install libffi-devel openssl-devel
+        - run: /opt/python/${{ matrix.python-path }}/bin/python -m venv .venv
+        - run: .venv/bin/pip install -U pip wheel
+        - run: .venv/bin/pip install -U twine maturin
+        - run: .venv/bin/pip install -r requirements.txt
+        - run: OPENSSL_STATIC=1 .venv/bin/maturin build --release --strip --manylinux 2_28 -i /opt/python/${{ matrix.python-path }}/bin/python --target x86_64-unknown-linux-gnu
+        - run: .venv/bin/pip install rfernet --no-index -f target/wheels
+        - run: .venv/bin/pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifier = [
 
 [tool.poetry]
 name = "rfernet"
-version = "0.3.0"
+version = "0.3.1"
 description = "Fast Fernet bindings for Python"
 authors = ["Aviram Hassan <aviramyhassan@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Switch github action and release build to `manylinux_2_28`. `manylinux_2_24` is [EOL as of Jan 1](https://github.com/pypa/manylinux/issues/1332). The last build for 0.3.0 did not get released due to a pipeline error.


Swaps the repo commands for Almalinux compatible ones, since the upstream base image has changed distro. I've also removed the explicit lib and include env vars for openssl-sys. The discovery method seems to work appropriately.

Tested by running the release wheel in a clean `python:3.11.4-bullseye` container.

Bumping the patch release as well to avoid conflicts on release. I've also included an update to the test actions, to pre-test  specifically for manylinux to catch build errors in the future.