### PR TITLE
Add release wheels for aarch64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,12 @@ on:
 
 
 jobs:
-  release_manylinux:
+  release_manylinux_x86_64:
     name: Release manylinux
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-path: ['cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311', 'cp312-cp312']
+        python-path: ['cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311', 'cp312-cp312', 'cp313-cp313']
     container: quay.io/pypa/manylinux_2_28_x86_64:latest
     env:
       TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
@@ -36,12 +36,40 @@ jobs:
       - run: .venv/bin/pytest
       - run: .venv/bin/twine upload --non-interactive --skip-existing target/wheels/*
 
+  release_manylinux_aarch64:
+    name: Release manylinux
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-path: ['cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311', 'cp312-cp312', 'cp313-cp313']
+    container: quay.io/pypa/manylinux_2_28_aarch64:latest
+    env:
+      TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
+      TWINE_USERNAME: ${{secrets.TWINE_USERNAME}}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: aarch64-unknown-linux-gnu
+      - run: yum makecache && yum -y install libffi-devel openssl-devel
+      - run: /opt/python/${{ matrix.python-path }}/bin/python -m venv .venv
+      - run: .venv/bin/pip install -U pip wheel
+      - run: .venv/bin/pip install -U twine maturin
+      - run: .venv/bin/pip install -r requirements.txt
+      - run: OPENSSL_STATIC=1 .venv/bin/maturin build --release --strip --manylinux 2_28 -i /opt/python/${{ matrix.python-path }}/bin/python --target aarch64-unknown-linux-gnu
+      - run: .venv/bin/pip install rfernet --no-index -f target/wheels
+      - run: .venv/bin/pytest
+      - run: .venv/bin/twine upload --non-interactive --skip-existing target/wheels/*
+
   release_macos:
     name: Release macOS
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        target-arch: ['x86_64-apple-darwin']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        target-arch: ['x86_64-apple-darwin', 'aarch64-apple-darwin']
     runs-on: macos-latest
     env:
       TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,14 +8,13 @@ on:
 
 
 jobs:
-  release_manylinux:
-    name: Release manylinux
+  release_manylinux_x86_64:
+    name: Release manylinux (x86_64)
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-path: ['cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311', 'cp312-cp312']
-        target-arch: ['x86_64', 'aarch64']
-    container: quay.io/pypa/manylinux_2_28_${{ matrix.target-arch }}:latest
+    container: quay.io/pypa/manylinux_2_28_x86_64:latest
     env:
       TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
       TWINE_USERNAME: ${{secrets.TWINE_USERNAME}}
@@ -26,13 +25,41 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-          target: ${{ matrix.target-arch }}-unknown-linux-gnu
+          target: x86_64-unknown-linux-gnu
       - run: yum makecache && yum -y install libffi-devel openssl-devel
       - run: /opt/python/${{ matrix.python-path }}/bin/python -m venv .venv
       - run: .venv/bin/pip install -U pip wheel
       - run: .venv/bin/pip install -U twine maturin
       - run: .venv/bin/pip install -r requirements.txt
-      - run: OPENSSL_STATIC=1 .venv/bin/maturin build --release --strip --manylinux 2_28 -i /opt/python/${{ matrix.python-path }}/bin/python --target ${{ matrix.target-arch }}-unknown-linux-gnu
+      - run: OPENSSL_STATIC=1 .venv/bin/maturin build --release --strip --manylinux 2_28 -i /opt/python/${{ matrix.python-path }}/bin/python --target x86_64-unknown-linux-gnu
+      - run: .venv/bin/pip install rfernet --no-index -f target/wheels
+      - run: .venv/bin/pytest
+      - run: .venv/bin/twine upload --non-interactive --skip-existing target/wheels/*
+
+  release_manylinux_aarch64:
+    name: Release manylinux (aarch64)
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      matrix:
+        python-path: ['cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311', 'cp312-cp312']
+    container: quay.io/pypa/manylinux_2_28_aarch64:latest
+    env:
+      TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
+      TWINE_USERNAME: ${{secrets.TWINE_USERNAME}}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: aarch64-unknown-linux-gnu
+      - run: yum makecache && yum -y install libffi-devel openssl-devel
+      - run: /opt/python/${{ matrix.python-path }}/bin/python -m venv .venv
+      - run: .venv/bin/pip install -U pip wheel
+      - run: .venv/bin/pip install -U twine maturin
+      - run: .venv/bin/pip install -r requirements.txt
+      - run: OPENSSL_STATIC=1 .venv/bin/maturin build --release --strip --manylinux 2_28 -i /opt/python/${{ matrix.python-path }}/bin/python --target aarch64-unknown-linux-gnu
       - run: .venv/bin/pip install rfernet --no-index -f target/wheels
       - run: .venv/bin/pytest
       - run: .venv/bin/twine upload --non-interactive --skip-existing target/wheels/*
@@ -42,7 +69,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        target-arch: ['x86_64-apple-darwin', 'aarch64-apple-darwin']
+        target-arch: ['aarch64-apple-darwin']
     runs-on: macos-latest
     env:
       TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
@@ -65,7 +92,7 @@ jobs:
       - run: pip install rfernet --no-index -f target/wheels
       - run: pytest
       - run: twine upload --non-interactive --skip-existing target/wheels/*
-  
+
   release_sdist:
     name: Release sdist
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,14 @@ on:
 
 
 jobs:
-  release_manylinux_x86_64:
+  release_manylinux:
     name: Release manylinux
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-path: ['cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311', 'cp312-cp312', 'cp313-cp313']
-    container: quay.io/pypa/manylinux_2_28_x86_64:latest
+        python-path: ['cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311', 'cp312-cp312']
+        target-arch: ['x86_64', 'aarch64']
+    container: quay.io/pypa/manylinux_2_28_${{ matrix.target-arch }}:latest
     env:
       TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
       TWINE_USERNAME: ${{secrets.TWINE_USERNAME}}
@@ -25,41 +26,13 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-          target: x86_64-unknown-linux-gnu
+          target: ${{ matrix.target-arch }}-unknown-linux-gnu
       - run: yum makecache && yum -y install libffi-devel openssl-devel
       - run: /opt/python/${{ matrix.python-path }}/bin/python -m venv .venv
       - run: .venv/bin/pip install -U pip wheel
       - run: .venv/bin/pip install -U twine maturin
       - run: .venv/bin/pip install -r requirements.txt
-      - run: OPENSSL_STATIC=1 .venv/bin/maturin build --release --strip --manylinux 2_28 -i /opt/python/${{ matrix.python-path }}/bin/python --target x86_64-unknown-linux-gnu
-      - run: .venv/bin/pip install rfernet --no-index -f target/wheels
-      - run: .venv/bin/pytest
-      - run: .venv/bin/twine upload --non-interactive --skip-existing target/wheels/*
-
-  release_manylinux_aarch64:
-    name: Release manylinux
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-path: ['cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311', 'cp312-cp312', 'cp313-cp313']
-    container: quay.io/pypa/manylinux_2_28_aarch64:latest
-    env:
-      TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
-      TWINE_USERNAME: ${{secrets.TWINE_USERNAME}}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          target: aarch64-unknown-linux-gnu
-      - run: yum makecache && yum -y install libffi-devel openssl-devel
-      - run: /opt/python/${{ matrix.python-path }}/bin/python -m venv .venv
-      - run: .venv/bin/pip install -U pip wheel
-      - run: .venv/bin/pip install -U twine maturin
-      - run: .venv/bin/pip install -r requirements.txt
-      - run: OPENSSL_STATIC=1 .venv/bin/maturin build --release --strip --manylinux 2_28 -i /opt/python/${{ matrix.python-path }}/bin/python --target aarch64-unknown-linux-gnu
+      - run: OPENSSL_STATIC=1 .venv/bin/maturin build --release --strip --manylinux 2_28 -i /opt/python/${{ matrix.python-path }}/bin/python --target ${{ matrix.target-arch }}-unknown-linux-gnu
       - run: .venv/bin/pip install rfernet --no-index -f target/wheels
       - run: .venv/bin/pytest
       - run: .venv/bin/twine upload --non-interactive --skip-existing target/wheels/*
@@ -68,7 +41,7 @@ jobs:
     name: Release macOS
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         target-arch: ['x86_64-apple-darwin', 'aarch64-apple-darwin']
     runs-on: macos-latest
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,13 +66,14 @@ jobs:
           command: clippy
           args: -- -D warnings
 
-  test_manylinux_release_x86_64:
-      name: Test manylinux release build (x86_64)
+  test_manylinux_release:
+      name: Test manylinux release build
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          python-path: ['cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311', 'cp312-cp312', 'cp313-cp313']
-      container: quay.io/pypa/manylinux_2_28_x86_64:latest
+          python-path: ['cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311', 'cp312-cp312']
+          target-arch: ['x86_64', 'aarch64']
+      container: quay.io/pypa/manylinux_2_28_${{ matrix.target-arch }}:latest
       steps:
         - uses: actions/checkout@v2
         - uses: actions-rs/toolchain@v1
@@ -80,36 +81,38 @@ jobs:
             profile: minimal
             toolchain: stable
             override: true
-            target: x86_64-unknown-linux-gnu
+            target: ${{ matrix.target-arch }}-unknown-linux-gnu
         - run: yum makecache && yum -y install libffi-devel openssl-devel
         - run: /opt/python/${{ matrix.python-path }}/bin/python -m venv .venv
         - run: .venv/bin/pip install -U pip wheel
         - run: .venv/bin/pip install -U twine maturin
         - run: .venv/bin/pip install -r requirements.txt
-        - run: OPENSSL_STATIC=1 .venv/bin/maturin build --release --strip --manylinux 2_28 -i /opt/python/${{ matrix.python-path }}/bin/python --target x86_64-unknown-linux-gnu
+        - run: OPENSSL_STATIC=1 .venv/bin/maturin build --release --strip --manylinux 2_28 -i /opt/python/${{ matrix.python-path }}/bin/python --target ${{ matrix.target-arch }}-unknown-linux-gnu
         - run: .venv/bin/pip install rfernet --no-index -f target/wheels
         - run: .venv/bin/pytest
 
-  test_manylinux_release_aarch64:
-      name: Test manylinux release build (aarch64)
-      runs-on: ubuntu-latest
-      strategy:
-        matrix:
-          python-path: ['cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311', 'cp312-cp312', 'cp313-cp313']
-      container: quay.io/pypa/manylinux_2_28_aarch64:latest
-      steps:
-        - uses: actions/checkout@v2
-        - uses: actions-rs/toolchain@v1
-          with:
-            profile: minimal
-            toolchain: stable
-            override: true
-            target: aarch64-unknown-linux-gnu
-        - run: yum makecache && yum -y install libffi-devel openssl-devel
-        - run: /opt/python/${{ matrix.python-path }}/bin/python -m venv .venv
-        - run: .venv/bin/pip install -U pip wheel
-        - run: .venv/bin/pip install -U twine maturin
-        - run: .venv/bin/pip install -r requirements.txt
-        - run: OPENSSL_STATIC=1 .venv/bin/maturin build --release --strip --manylinux 2_28 -i /opt/python/${{ matrix.python-path }}/bin/python --target aarch64-unknown-linux-gnu
-        - run: .venv/bin/pip install rfernet --no-index -f target/wheels
-        - run: .venv/bin/pytest
+  test_release_macos:
+    name: Test macOS release build
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        target-arch: ['x86_64-apple-darwin', 'aarch64-apple-darwin']
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: ${{ matrix.target-arch }}
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -U pip wheel twine maturin
+      - run: pip install -U twine maturin
+      - run: pip install -r requirements.txt
+      - run: maturin build --release --strip --manylinux off -i $pythonLocation/python --target ${{ matrix.target-arch }}
+      - run: pip install rfernet --no-index -f target/wheels
+      - run: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,12 +66,12 @@ jobs:
           command: clippy
           args: -- -D warnings
 
-  test_manylinux_release:
-      name: Test manylinux release build
+  test_manylinux_release_x86_64:
+      name: Test manylinux release build (x86_64)
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          python-path: ['cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311', 'cp312-cp312']
+          python-path: ['cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311', 'cp312-cp312', 'cp313-cp313']
       container: quay.io/pypa/manylinux_2_28_x86_64:latest
       steps:
         - uses: actions/checkout@v2
@@ -87,5 +87,29 @@ jobs:
         - run: .venv/bin/pip install -U twine maturin
         - run: .venv/bin/pip install -r requirements.txt
         - run: OPENSSL_STATIC=1 .venv/bin/maturin build --release --strip --manylinux 2_28 -i /opt/python/${{ matrix.python-path }}/bin/python --target x86_64-unknown-linux-gnu
+        - run: .venv/bin/pip install rfernet --no-index -f target/wheels
+        - run: .venv/bin/pytest
+
+  test_manylinux_release_aarch64:
+      name: Test manylinux release build (aarch64)
+      runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          python-path: ['cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311', 'cp312-cp312', 'cp313-cp313']
+      container: quay.io/pypa/manylinux_2_28_aarch64:latest
+      steps:
+        - uses: actions/checkout@v2
+        - uses: actions-rs/toolchain@v1
+          with:
+            profile: minimal
+            toolchain: stable
+            override: true
+            target: aarch64-unknown-linux-gnu
+        - run: yum makecache && yum -y install libffi-devel openssl-devel
+        - run: /opt/python/${{ matrix.python-path }}/bin/python -m venv .venv
+        - run: .venv/bin/pip install -U pip wheel
+        - run: .venv/bin/pip install -U twine maturin
+        - run: .venv/bin/pip install -r requirements.txt
+        - run: OPENSSL_STATIC=1 .venv/bin/maturin build --release --strip --manylinux 2_28 -i /opt/python/${{ matrix.python-path }}/bin/python --target aarch64-unknown-linux-gnu
         - run: .venv/bin/pip install rfernet --no-index -f target/wheels
         - run: .venv/bin/pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,14 +66,13 @@ jobs:
           command: clippy
           args: -- -D warnings
 
-  test_manylinux_release:
-      name: Test manylinux release build
+  test_manylinux_release_x86_64:
+      name: Test manylinux release build (x86_64)
       runs-on: ubuntu-latest
       strategy:
         matrix:
           python-path: ['cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311', 'cp312-cp312']
-          target-arch: ['x86_64', 'aarch64']
-      container: quay.io/pypa/manylinux_2_28_${{ matrix.target-arch }}:latest
+      container: quay.io/pypa/manylinux_2_28_x86_64:latest
       steps:
         - uses: actions/checkout@v2
         - uses: actions-rs/toolchain@v1
@@ -81,13 +80,37 @@ jobs:
             profile: minimal
             toolchain: stable
             override: true
-            target: ${{ matrix.target-arch }}-unknown-linux-gnu
+            target: x86_64-unknown-linux-gnu
         - run: yum makecache && yum -y install libffi-devel openssl-devel
         - run: /opt/python/${{ matrix.python-path }}/bin/python -m venv .venv
         - run: .venv/bin/pip install -U pip wheel
         - run: .venv/bin/pip install -U twine maturin
         - run: .venv/bin/pip install -r requirements.txt
-        - run: OPENSSL_STATIC=1 .venv/bin/maturin build --release --strip --manylinux 2_28 -i /opt/python/${{ matrix.python-path }}/bin/python --target ${{ matrix.target-arch }}-unknown-linux-gnu
+        - run: OPENSSL_STATIC=1 .venv/bin/maturin build --release --strip --manylinux 2_28 -i /opt/python/${{ matrix.python-path }}/bin/python --target x86_64-unknown-linux-gnu
+        - run: .venv/bin/pip install rfernet --no-index -f target/wheels
+        - run: .venv/bin/pytest
+
+  test_manylinux_release_aarch64:
+      name: Test manylinux release build (aarch64)
+      runs-on: ubuntu-24.04-arm
+      strategy:
+        matrix:
+          python-path: ['cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311', 'cp312-cp312']
+      container: quay.io/pypa/manylinux_2_28_aarch64:latest
+      steps:
+        - uses: actions/checkout@v2
+        - uses: actions-rs/toolchain@v1
+          with:
+            profile: minimal
+            toolchain: stable
+            override: true
+            target: aarch64-unknown-linux-gnu
+        - run: yum makecache && yum -y install libffi-devel openssl-devel
+        - run: /opt/python/${{ matrix.python-path }}/bin/python -m venv .venv
+        - run: .venv/bin/pip install -U pip wheel
+        - run: .venv/bin/pip install -U twine maturin
+        - run: .venv/bin/pip install -r requirements.txt
+        - run: OPENSSL_STATIC=1 .venv/bin/maturin build --release --strip --manylinux 2_28 -i /opt/python/${{ matrix.python-path }}/bin/python --target aarch64-unknown-linux-gnu
         - run: .venv/bin/pip install rfernet --no-index -f target/wheels
         - run: .venv/bin/pytest
 
@@ -96,7 +119,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        target-arch: ['x86_64-apple-darwin', 'aarch64-apple-darwin']
+        target-arch: ['aarch64-apple-darwin']
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,15 +213,16 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a89dc7a5850d0e983be1ec2a463a171d20990487c3cfcd68b5363f1ee3d6fe0"
+checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset",
  "parking_lot",
+ "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -224,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07426f0d8fe5a601f26293f300afd1a7b1ed5e78b2a705870c5f30893c5163be"
+checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -234,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb7dec17e17766b46bca4f1a4215a85006b4c2ecde122076c562dd058da6cf1"
+checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -244,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f738b4e40d50b5711957f142878cfa0f28e054aa0ebdfc3fd137a843f74ed3"
+checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -256,12 +263,13 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc910d4851847827daf9d6cdd4a823fbdaab5b8818325c5e97a86da79e8881f"
+checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
 dependencies = [
  "heck",
  "proc-macro2",
+ "pyo3-build-config",
  "quote",
  "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,5 @@ fernet = "*"
 once_cell = "1.17.0"
 
 [dependencies.pyo3]
-version = "*"
-features = ["extension-module"]
+version = "0.21.2"
+features = ["extension-module", "gil-refs"]


### PR DESCRIPTION
Hello again @aviramha 

This PR adds support for prebuilt wheels on aarch64. The manylinux version is matched up to the x86_64 build for consistency. 

IIRC there were previously build issues when I tried this last time, but I ran through the build locally (with the matching manylinux env) and it seems to be working well now.

The tests are matched up with the release variants, and I included the MacOS builds as well. It appears the MacOS builds are outright broken, so I have removed that variant for now.

On the first builds of this PR, clippy was throwing some warnings. Rather than ignore them, these warnings were fixed in `pyo3@0.21.5`, which was the lowest-impact upgrade I could make. I also needed to enable `gil-refs` for backwards compatibility, but that should not change any behavior.